### PR TITLE
feat: Update shell scripts shebangs to be generic for NixOS/*BSD

### DIFF
--- a/install-shortcut.sh
+++ b/install-shortcut.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Install desktop file to launch FAF from launcher
 
 ICON_URL="https://www.faforever.com/images/faf-logo.png"

--- a/launchwrapper
+++ b/launchwrapper
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Wrapper for launching wine programs in the prefix
 
 basedir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"

--- a/launchwrapper-env
+++ b/launchwrapper-env
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Run command in environment, but without wine
 
 basedir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"

--- a/run
+++ b/run
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Start the FAF client
 
 basedir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"

--- a/run-offline
+++ b/run-offline
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 basedir=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
 "$basedir/launchwrapper" ~/.faforever/bin/ForgedAlliance.exe /init "${@:-init.lua}"

--- a/set-client-paths.sh
+++ b/set-client-paths.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Script to automatically set paths for the FAF client
 
 basedir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"

--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Main setup script
 set -eE
 trap 'echo; echo "Script error! The installation has failed. Please report this to the author."' ERR

--- a/tools/dxvk-install.sh
+++ b/tools/dxvk-install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 # usage: dxvk-install.sh <extracted>
 # intended to be wrapped with launchwrapper-env

--- a/update-component.sh
+++ b/update-component.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Update specific components
 # Currently supports updating dxvk and the faf client
 set -e

--- a/update.sh
+++ b/update.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Compare versions against target versions ("versions" file) and update if requested
 
 basedir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"


### PR DESCRIPTION
To follow [posix standards](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/sh.html#tag_20_117_16) bash scripts should be:
```bash
```
Instead of:
```bash
```

This makes sure that these scripts also work for NixOS and some flavors of BSD.